### PR TITLE
Add Device Location Fetching

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -36,24 +36,35 @@ function App() {
 
   // Effect to get the current position of the device
   useEffect(() => {
-    // Define options for geolocation
-    const options = {
-      enableHighAccuracy: true,
-      timeout: 5000,
-      maximumAge: 0,
-    };    
-    // Success callback
-    function success(pos: GeolocationPosition): void {
-      const crd = pos.coords;
-      setCurrentPosition(`${crd.latitude},${crd.longitude}`);
-    }
-    // Error Callback
-    function error(err: GeolocationPositionError): void {
-      console.warn(`ERROR(${err.code}): ${err.message}`);
-    }
-    
-    navigator.geolocation.getCurrentPosition(success, error, options);
+    navigator.permissions.query({ name: 'geolocation' })
+      .then((result) => {
+        // Define options for geolocation
+        const options = {
+          enableHighAccuracy: true,
+          timeout: 5000,
+          maximumAge: 0,
+        };    
+        // Success callback
+        function success(pos: GeolocationPosition): void {
+          const crd = pos.coords;
+          setCurrentPosition(`${crd.latitude},${crd.longitude}`);
+        }
+        // Error Callback
+        function error(err: GeolocationPositionError): void {
+          console.warn(`ERROR(${err.code}): ${err.message}`);
+        }
+
+        if (result.state === 'granted') {
+          navigator.geolocation.getCurrentPosition(success);
+        } else if (result.state === 'prompt') {
+          navigator.geolocation.getCurrentPosition(success, error, options);
+        }
+      })
   }, [])
+
+  useEffect(() => {
+    console.log(currentPosition)
+  }, [currentPosition])
 
   // Effect to fetch nearby restaurants when current position or search location is updated
   useEffect(() => {

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -46,8 +46,8 @@ function App() {
         };    
         // Success callback
         function success(pos: GeolocationPosition): void {
-          const crd = pos.coords;
-          setCurrentPosition(`${crd.latitude},${crd.longitude}`);
+          const coordinates = pos.coords;
+          setCurrentPosition(`${coordinates.latitude},${coordinates.longitude}`);
         }
         // Error Callback
         function error(err: GeolocationPositionError): void {
@@ -61,10 +61,6 @@ function App() {
         }
       })
   }, [])
-
-  useEffect(() => {
-    console.log(currentPosition)
-  }, [currentPosition])
 
   // Effect to fetch nearby restaurants when current position or search location is updated
   useEffect(() => {

--- a/src/components/EatItOrLeaveIt.tsx
+++ b/src/components/EatItOrLeaveIt.tsx
@@ -1,7 +1,7 @@
 import whatsEat from "../assets/icons/whatsEat-icon.png";
 import eatIt from "../assets/icons/eat-it.png";
 import leaveIT from "../assets/icons/leave-it.png";
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import {
   UserInfo,
   FoodInfoDisplay,
@@ -10,24 +10,21 @@ import {
 } from "../vite-env";
 import {
   sendNewRecord,
-  fetchRecommendation,
   addNewFood,
-  fetchLocationByIP,
-  fetchNearbyRestaurants,
 } from "../helper/fetchHelper";
 
 interface EatItOrLeaveItProps {
   currentUser: UserInfo;
   setView: Function;
+  nearbyRestaurants: RestaurantInfo[];
 }
 
 const EatItOrLeaveIt: React.FC<EatItOrLeaveItProps> = ({
   currentUser,
   setView,
+  nearbyRestaurants,
 }) => {
 
-  const [currentLocation, setCurrentLocation] = useState<string | null>(null);
-  const [nearbyRestaurants, setNearbyRestaurants] = useState<RestaurantInfo[]>([]);
   const [randomRestaurant, setRandomRestaurant] = useState<RestaurantInfo | null>(null);
   const [usedIndices, setUsedIndices] = useState<Number[]>([]);
 
@@ -47,27 +44,6 @@ const EatItOrLeaveIt: React.FC<EatItOrLeaveItProps> = ({
     setRandomRestaurant(nearbyRestaurants[randomIndex]);
     setUsedIndices([...usedIndices, randomIndex])
   };
-
-  // Effect to fetch nearby restaurants when current location is updated
-  useEffect(() => {
-    if (currentLocation) {
-      fetchNearbyRestaurants(`restaurants/nearby?location=${currentLocation}`)
-        .then(data => {
-          setNearbyRestaurants(Array.isArray(data) ? data : []);
-        })
-        .catch(error => {
-          console.error('Error fetching data:', error);
-        })
-    }
-  }, [currentLocation])
-
-  useEffect(() => {
-    const resolveRecommendation = async () => {
-      getNextRestaurant();
-      await fetchLocationByIP();
-    };
-    resolveRecommendation();
-  }, []);
 
   const handleDeleteFood = () => {
     getNextRestaurant();


### PR DESCRIPTION
### Key Changes:

**Device Location Fetching (First useEffect):**

- Uses the `navigator.geolocation.getCurrentPosition` API to fetch the current geolocation of the user's device.
- Defines options to enable high accuracy, set a timeout of 5000ms, and prevent using cached data.
- On success, updates the state `currentPosition` with the device's latitude and longitude.

**Nearby Restaurants Fetching (Second useEffect):**

- Moved from `EatItOrLeaveIt` component to `App` component
- Triggers when the `currentPosition` or `searchLocation` changes.
- If `currentPosition` is available, it fetches nearby restaurants using the device's coordinates.
- If `currentPosition` is not available, it falls back to using the `searchLocation` to fetch nearby restaurants.
- In both cases, the fetched data is validated and stored in the `nearbyRestaurants` state.